### PR TITLE
Fix SNI crash

### DIFF
--- a/src/ssl/ssl_context.h
+++ b/src/ssl/ssl_context.h
@@ -112,7 +112,7 @@ class SSLContext {
    * @return SSL_TLSEXT_ERR_OK if everything is ok, if not return an OpenSSL
    * error code.
    */
-  static int SNIServerName(SSL *ssl, int dummy, SSLData *ctx);
+  static int SNIServerName(SSL *ssl, int dummy, POUND_CTX *ctx);
 
   /**
    * @brief Check if the @p engine_id set in the configuration file is valid and


### PR DESCRIPTION
When using SNI, on of the following will happen:

* the wrong certificate gets chosen, or
* the zproxy crashes 

This happens because the provided argument type is different from the callback function.

I simply changed the type to fix it. Now SNI is working, again.